### PR TITLE
ignore error when add lxc remote

### DIFF
--- a/gitlabci-build-base.sh
+++ b/gitlabci-build-base.sh
@@ -1,10 +1,10 @@
 set -x
 set -e
-lxc remote add --protocol simplestreams ubuntu-minimal https://cloud-images.ubuntu.com/minimal/releases/
-if [ -z "$TEMPLATE_FILE" ]; then 
-  CONFIG_PATH=${1:-./packer.json};
-else 
-  CONFIG_PATH=$TEMPLATE_FILE;  
+lxc remote add --protocol simplestreams ubuntu-minimal https://cloud-images.ubuntu.com/minimal/releases/ || true
+if [ -z "$TEMPLATE_FILE" ]; then
+  CONFIG_PATH=${1:-./packer.json}
+else
+  CONFIG_PATH=$TEMPLATE_FILE
 fi
 ./packer/packer build $CONFIG_PATH
 lxc image list


### PR DESCRIPTION
https://github.com/BaritoLog/cx-scripts/issues/5

before
```
$ lxc remote add --protocol simplestreams ubuntu-minimal https://cloud-images.ubuntu.com/minimal/releases
Error: Remote ubuntu-minimal exists as <https://cloud-images.ubuntu.com/minimal/releases/>
$ echo $?
1
```
after
```$ lxc remote add --protocol simplestreams ubuntu-minimal https://cloud-images.ubuntu.com/minimal/releases/ || true
Error: Remote ubuntu-minimal exists as <https://cloud-images.ubuntu.com/minimal/releases/>
$ echo $?
```